### PR TITLE
feat(config): Show hierarchical position of the config file error

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -109,19 +109,26 @@ namespace CityFlow {
             std::cerr << "cannot open flow file!" << std::endl;
             return false;
         }
-
+        std::list<std::string> path;
         try {
             if (!root.IsArray())
                 throw JsonTypeError("flow file", "array");
             for (rapidjson::SizeType i = 0; i < root.Size(); i++) {
+                path.emplace_back("flow[" + std::to_string(i) + "]");
                 rapidjson::Value &flow = root[i];
                 std::vector<Road *> roads;
                 const auto &routes = getJsonMemberArray("route", flow);
                 roads.reserve(routes.Size());
                 for (auto &route: routes.GetArray()) {
+                    path.emplace_back("route[" + std::to_string(roads.size()) + "]");
                     if (!route.IsString())
                         throw JsonTypeError("route", "string");
-                    roads.push_back(roadnet.getRoadById(route.GetString()));
+                    std::string roadName = route.GetString();
+                    auto road = roadnet.getRoadById(roadName);
+                    if (!road)
+                        throw JsonFormatError("No such road: " + roadName);
+                    roads.push_back(road);
+                    path.pop_back();
                 }
                 auto route = std::make_shared<const Route>(roads);
 
@@ -142,9 +149,15 @@ namespace CityFlow {
                 Flow newFlow(vehicleInfo, getJsonMember<double>("interval", flow), this, startTime, endTime,
                              "flow_" + std::to_string(i));
                 flows.push_back(newFlow);
+                path.pop_back();
             }
+            assert(path.empty());
         } catch (const JsonFormatError &e) {
-            std::cerr << e.what() << std::endl;
+            std::cerr << "Error occurred when reading flow file" << std::endl;
+            for (const auto &node : path) {
+                std::cerr << "/" << node;
+            }
+            std::cerr << " " << e.what() << std::endl;
             return false;
         }
         return true;

--- a/src/utility/utility.cpp
+++ b/src/utility/utility.cpp
@@ -5,8 +5,10 @@
 
 #include "rapidjson/filereadstream.h"
 #include "rapidjson/filewritestream.h"
+#include "rapidjson/cursorstreamwrapper.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/document.h"
+#include "rapidjson/error/en.h"
 
 namespace CityFlow {
 
@@ -98,7 +100,14 @@ namespace CityFlow {
         }
         char readBuffer[JSON_BUFFER_SIZE];
         rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
-        document.ParseStream(is);
+        rapidjson::CursorStreamWrapper<rapidjson::FileReadStream> csw(is);
+        document.ParseStream(csw);
+        if (document.HasParseError()) {
+            std::cerr << "Json parsing error at line " << csw.GetLine() << std::endl;
+            std::cerr << rapidjson::GetParseError_En(document.GetParseError());
+            std::cerr << std::endl;
+            return false;
+        }
         fclose(fp);
         return true;
     }


### PR DESCRIPTION
 - If there is a parsing error, the simulator will print the error message and the line number
 - If an error is caused by  wrong format like an absence of a required member in a JSON object, the simulator will print the hierarchical position of it, like /roads/road_0_1_0