### PR TITLE
feat(laneChange): new lane changing mechanism

### DIFF
--- a/src/cityflow.cpp
+++ b/src/cityflow.cpp
@@ -30,6 +30,8 @@ PYBIND11_MODULE(cityflow, m) {
         .def("set_replay_file", &CityFlow::Engine::setReplayLogFile, "replay_file"_a)
         .def("set_random_seed", &CityFlow::Engine::setRandomSeed, "seed"_a)
         .def("set_save_replay", &CityFlow::Engine::setSaveReplay, "open"_a)
+        .def("set_lane_change", &CityFlow::Engine::setLaneChange, "vehicle_id"_a, "direction"_a)
+        .def("get_lane_changing_vehicles", &CityFlow::Engine::getLaneChangingVehicles)
         .def("push_vehicle", (void (CityFlow::Engine::*)(const std::map<std::string, double>&, const std::vector<std::string>&)) &CityFlow::Engine::pushVehicle)
         .def("reset", &CityFlow::Engine::reset, "seed"_a=false)
         .def("load", &CityFlow::Engine::load, "archive"_a)

--- a/src/engine/archive.cpp
+++ b/src/engine/archive.cpp
@@ -140,11 +140,11 @@ namespace CityFlow {
             vehicle->controllerInfo.leader  = getNewPointer(newPool, vehicle->controllerInfo.leader);
             vehicle->controllerInfo.blocker = getNewPointer(newPool, vehicle->controllerInfo.blocker);
 
-            std::shared_ptr<LaneChange> laneChange = vehicle->laneChange;
-            laneChange->targetLeader = getNewPointer(newPool, laneChange->targetLeader);
-            laneChange->targetFollower = getNewPointer(newPool, laneChange->targetFollower);
-            if (laneChange->signalRecv) {
-                laneChange->signalRecv = getNewPointer(newPool, laneChange->signalRecv->source)->laneChange->signalSend;
+            LaneChange &laneChange = vehicle->laneChange;
+            laneChange.targetLeader = getNewPointer(newPool, laneChange.targetLeader);
+            laneChange.targetFollower = getNewPointer(newPool, laneChange.targetFollower);
+            if (laneChange.signalRecv) {
+                laneChange.signalRecv = getNewPointer(newPool, laneChange.signalRecv->source)->laneChange.signalSend;
             }
         }
         return newPool;
@@ -229,21 +229,21 @@ namespace CityFlow {
         vehicleValue.AddMember("partnerType", vehicle.laneChangeInfo.partnerType, allocator);
         addObjectAsMember(vehicleValue, "partner", vehicle.laneChangeInfo.partner, allocator);
         vehicleValue.AddMember("offset", vehicle.laneChangeInfo.offset, allocator);
-        if (vehicle.laneChange->signalSend) {
-            auto &signal = vehicle.laneChange->signalSend;
+        if (vehicle.laneChange.signalSend) {
+            auto &signal = vehicle.laneChange.signalSend;
             vehicleValue.AddMember("laneChangeUrgency", signal->urgency, allocator);
             vehicleValue.AddMember("laneChangeDirection", signal->direction, allocator);
             addObjectAsMember(vehicleValue, "laneChangeTarget", signal->target, allocator);
         }
-        if (vehicle.laneChange->signalRecv) {
-            auto &signal = vehicle.laneChange->signalRecv;
+        if (vehicle.laneChange.signalRecv) {
+            auto &signal = vehicle.laneChange.signalRecv;
             addObjectAsMember(vehicleValue, "laneChangeRecv", signal->source, allocator);
         }
-        addObjectAsMember(vehicleValue, "laneChangeLeader", vehicle.laneChange->targetLeader, allocator);
-        addObjectAsMember(vehicleValue, "laneChangeFollower", vehicle.laneChange->targetFollower, allocator);
-        vehicleValue.AddMember("laneChangeWaitingTime", vehicle.laneChange->waitingTime, allocator);
-        vehicleValue.AddMember("laneChanging", vehicle.laneChange->changing, allocator);
-        vehicleValue.AddMember("laneChangeLastTime", vehicle.laneChange->lastChangeTime, allocator);
+        addObjectAsMember(vehicleValue, "laneChangeLeader", vehicle.laneChange.targetLeader, allocator);
+        addObjectAsMember(vehicleValue, "laneChangeFollower", vehicle.laneChange.targetFollower, allocator);
+        vehicleValue.AddMember("laneChangeWaitingTime", vehicle.laneChange.waitingTime, allocator);
+        vehicleValue.AddMember("laneChanging", vehicle.laneChange.changing, allocator);
+        vehicleValue.AddMember("laneChangeLastTime", vehicle.laneChange.lastChangeTime, allocator);
 
         return vehicleValue;
     }
@@ -409,7 +409,6 @@ namespace CityFlow {
             laneChangeInfo.offset = getJsonMember<double>("offset", vehicleValue);
 
             // Construct the laneChange Object
-            vehicle->laneChange = std::make_shared<SimpleLaneChange>(vehicle);
             auto &laneChange = vehicle->laneChange;
             rapidjson::Value::ConstMemberIterator sendItr = vehicleValue.FindMember("laneChangeUrgency");
             if (sendItr != vehicleValue.MemberEnd()) {
@@ -417,11 +416,11 @@ namespace CityFlow {
                 signal->source = vehicle;
                 signal->urgency = sendItr->value.GetInt();
                 signal->direction = getJsonMember<int>("laneChangeDirection", vehicleValue);
-                laneChange->signalSend = signal;
+                laneChange.signalSend = signal;
             }
-            laneChange->waitingTime = getJsonMember<double>("laneChangeWaitingTime", vehicleValue);
-            laneChange->changing = getJsonMember<bool>("laneChanging", vehicleValue);
-            laneChange->lastChangeTime = getJsonMember<double>("laneChangeLastTime", vehicleValue);
+            laneChange.waitingTime = getJsonMember<double>("laneChangeWaitingTime", vehicleValue);
+            laneChange.changing = getJsonMember<bool>("laneChanging", vehicleValue);
+            laneChange.lastChangeTime = getJsonMember<double>("laneChangeLastTime", vehicleValue);
         }
 
         // restore pointer relations
@@ -449,8 +448,8 @@ namespace CityFlow {
                 vehicle->laneChangeInfo.partner = vehicleDict[partnerId];
             }
 
-            if (vehicle->laneChange->signalSend) {
-                auto &signal = vehicle->laneChange->signalSend;
+            if (vehicle->laneChange.signalSend) {
+                auto &signal = vehicle->laneChange.signalSend;
                 const char *targetId = getJsonMember<const char *>("laneChangeTarget", vehicleValue, nullptr);
                 assert(targetId);
                 Drivable *target = engine.roadnet.getDrivableById(targetId);
@@ -461,17 +460,17 @@ namespace CityFlow {
             rapidjson::Value::ConstMemberIterator signalRecvIter = vehicleValue.FindMember("laneChangeRecv");
             if (signalRecvIter != vehicleValue.MemberEnd()) {
                 std::string sourceId = signalRecvIter->value.GetString();
-                vehicle->laneChange->signalRecv = vehicleDict[sourceId]->laneChange->signalSend;
+                vehicle->laneChange.signalRecv = vehicleDict[sourceId]->laneChange.signalSend;
             }
 
             const char *laneChangeLeaderId = getJsonMember<const char*>("laneChangeLeader", vehicleValue, nullptr);
             if (laneChangeLeaderId) {
-                vehicle->laneChange->targetLeader = vehicleDict[laneChangeLeaderId];
+                vehicle->laneChange.targetLeader = vehicleDict[laneChangeLeaderId];
             }
 
             const char *laneChangeFollowerId = getJsonMember<const char*>("laneChangeFollower", vehicleValue, nullptr);
             if (laneChangeFollowerId) {
-                vehicle->laneChange->targetFollower = vehicleDict[laneChangeFollowerId];
+                vehicle->laneChange.targetFollower = vehicleDict[laneChangeFollowerId];
             }
         }
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -158,7 +158,7 @@ namespace CityFlow {
 
         std::map<std::string, double> getVehicleDistance() const;
 
-        std::string getLeader(const std::string &vehicleId) const;
+        std::string getLeader(const std::string &id) const;
 
         double getCurrentTime() const;
 
@@ -171,6 +171,10 @@ namespace CityFlow {
         void setSaveReplay(bool open);
 
         void setVehicleSpeed(const std::string &id, double speed);
+
+        void setLaneChange(const std::string &id, int direction);
+
+        std::vector<std::string> getLaneChangingVehicles();
 
         void setRandomSeed(int seed) { rnd.seed(seed); }
         

--- a/src/roadnet/roadnet.cpp
+++ b/src/roadnet/roadnet.cpp
@@ -871,7 +871,7 @@ FOUND:;
             auto vehs = getSegment(i)->getVehicles();
             for (auto itr = vehs.begin() ; itr != vehs.end(); ++itr){
                 auto &vehicle = **itr;
-                if (vehicle->getDistance() < dis) return **itr;
+                if (vehicle->getDistance() <= dis) return **itr;
             }
         }
 

--- a/src/vehicle/lanechange.cpp
+++ b/src/vehicle/lanechange.cpp
@@ -114,6 +114,7 @@ namespace CityFlow{
 
     void LaneChange::finishChanging() {
         changing = false;
+        angle = 0;
         finished = true;
         lastChangeTime = vehicle->engine->getCurrentTime();
         Vehicle *partner = vehicle->getPartner();
@@ -136,92 +137,234 @@ namespace CityFlow{
         if (changing) return;
         signalSend = nullptr;
         signalRecv = nullptr;
+        clearCustomDirection();
     }
 
-    void LaneChange::abortChanging() {
-        Vehicle *partner = vehicle->getPartner();
-        partner->laneChange->changing = false;
-        partner->laneChangeInfo.partnerType = 0;
-        partner->laneChangeInfo.offset = 0;
-        partner->laneChangeInfo.partner = nullptr;
-        clearSignal();
+    Lane *LaneChange::nearestAvailableLane() const {
+        Lane *curLane = vehicle->getCurLane();
+        Road *curRoad = curLane->getBelongRoad();
+        const Router &router = vehicle->controllerInfo.router;
+        int left, right, laneCnt = curRoad->getLanes().size();
+        for (left = right = curLane->getLaneIndex() ; left >=0 || right < laneCnt ; --left, ++right){
+            if (left >= 0) {
+                Lane *leftLane = curRoad->getLanePointers()[left];
+                if (router.getNextDrivable(leftLane))
+                    return leftLane;
+            }
+            if (right < laneCnt) {
+                Lane *rightLane = curRoad->getLanePointers()[right];
+                if (router.getNextDrivable(rightLane))
+                    return rightLane;
+            }
+        }
+        return nullptr;
     }
 
+    double LaneChange::safeDistance(Lane *lane) const {
+        Lane *targetLane = nearestAvailableLane();
+        assert(targetLane);
+        int direction = targetLane->getLaneIndex() > lane->getLaneIndex() ? 1 : -1;
+        double lcReplacement = 0;
+        const auto &lanes = lane->getBelongRoad()->getLanePointers();
+        for (size_t i = lane->getLaneIndex() ; i != targetLane->getLaneIndex() ; i += direction) {
+            lcReplacement += (lanes[i]->getWidth() + lanes[i + direction]->getWidth()) / 2;
+        }
+        int dIndex = static_cast<int>(targetLane->getLaneIndex()) - static_cast<int>(lane->getLaneIndex());
+        return lcReplacement / ratio + abs(dIndex) * vehicle->getMaxSpeed() * vehicle->engine->getInterval();
+    }
 
-    void SimpleLaneChange::makeSignal(double interval) {
-        if (changing) return;
-        if (vehicle->engine->getCurrentTime() - lastChangeTime < coolingTime) return;
+    double LaneChange::safeDistance() const {
+        return safeDistance(vehicle->getCurLane());
+    }
+
+    double LaneChange::forceLaneChangeSpeed() const {
+        auto &router = vehicle->controllerInfo.router;
+        if (!vehicle->getCurDrivable()->isLane() || router.onValidLane() || changing || !vehicle->isReal())
+            return vehicle->getMaxSpeed();
+        Lane *curLane = vehicle->getCurLane();
+        double safeDistance = curLane->getLength() - this->safeDistance() - vehicle->getDistance();
+        if (planChange() && !signalRecv) {
+            if (targetFollower && targetFollower->getLaneChange().planChange() && targetFollower->getSpeed() == 0 &&
+                vehicle->getDistance() - targetFollower->getDistance() < vehicle->getLen()) {
+                if (safeDistance > 0)
+//                    return vehicle->getStopBeforeSpeed(safeDistance, vehicle->engine->getInterval());
+                    return vehicle->getMaxSpeed();
+                else return -100;
+            }
+        }
+        if (safeDistance -  vehicle->getLen() > 0)
+            return vehicle->getStopBeforeSpeed(safeDistance -  vehicle->getLen(), vehicle->engine->getInterval());
+        else return -100;
+    }
+
+    double LaneChange::getDeltaOffset(double deltaDis) const {
+        double deltaOffset = ratio * deltaDis;
+        double minimalDeltaOffset = minimalLaneChangeSpeed * vehicle->engine->getInterval();
+        if (deltaOffset > 0) return deltaOffset;
+        else {
+            std::uniform_real_distribution<double> dis(0.0, 1.0);
+            double chance = dis(vehicle->engine->rnd);
+            if (chance < minimalSpeedChance)
+                return minimalDeltaOffset;
+            else
+                return 0;
+        }
+    }
+
+    double LaneChange::safeDistance(double deltaOffset) const {
+        return deltaOffset / ratio + vehicle->getMaxSpeed() * vehicle->engine->getInterval();
+    }
+
+    void LaneChange::changeToInner() {
+        if (vehicle->getDistance() + vehicle->getMinBrakeDistance() >= vehicle->getCurDrivable()->getLength()) return;
         signalSend = std::make_shared<Signal>();
         signalSend->source = vehicle;
+        signalSend->target = vehicle->getCurLane()->getInnerLane();
+        signalSend->direction = getDirection();
+    }
+
+    void LaneChange::changeToOuter() {
+        if (vehicle->getDistance() + vehicle->getMinBrakeDistance() >= vehicle->getCurDrivable()->getLength()) return;
+        signalSend = std::make_shared<Signal>();
+        signalSend->source = vehicle;
+        signalSend->target = vehicle->getCurLane()->getOuterLane();
+        signalSend->direction = getDirection();
+    }
+
+    double LaneChange::laneChangeAngle() const {
+        if (!changing) return 0;
+        return angle;
+    }
+
+    bool LaneChange::isGapValid() const {
+        return gapAfter() >= safeGapAfter() && gapBefore() >= safeGapBefore();
+    }
+
+    void LaneChange::updateAngle(double dx, double dy) {
+        if (!changing) angle = 0;
+        double maxAngle = atan2(0.6, 1);
+        double p = fabs(vehicle->laneChangeInfo.offset) / vehicle->getMaxOffset();
+        double angleByPos = (0.9 - 1.6 * min2double(fabs(p - 0.5), 0.5)) * maxAngle;
+        double angleBySpeed = min2double(atan2(dx, dy), maxAngle);
+        double newAngle = (dy < 0.1) ? angleByPos: min2double(angleByPos, angleBySpeed);
+
+        angle = (angle - signalSend->direction * newAngle) / 2;
+    }
+
+    void LaneChange::makeSignal(double interval) {
+        if (changing) return;
+
         if (vehicle->getCurDrivable()->isLane()) {
             Lane *curLane = (Lane *)vehicle->getCurDrivable();
-
-            if (curLane->getLength() - vehicle->getDistance() < 30) return;
-            double curEst = vehicle->getGap();
-            double outerEst = 0;
-            double expectedGap = 2 * vehicle->getLen() + 4 * interval * vehicle->getMaxSpeed();
-            if (vehicle->getGap() > expectedGap || vehicle->getGap() < 1.5 * vehicle->getLen()) return;
+            const Road *curRoad = curLane->getBelongRoad();
+            if (isCustomDirectionSet) {
+                if (customDirection == -1 && curLane->getLaneIndex() > 0) {
+                    changeToInner();
+                }else if (customDirection == 1 && curLane->getLaneIndex() < curRoad->getLanes().size() - 1) {
+                    changeToOuter();
+                }
+                return ;
+            }
 
             Router &router = vehicle->controllerInfo.router;
-            if (curLane->getLaneIndex() < curLane->getBelongRoad()->getLanes().size() - 1){
-                if (router.onLastRoad() || router.getNextDrivable(curLane->getOuterLane())) {
-                    outerEst = estimateGap(curLane->getOuterLane());
-                    if (outerEst > curEst + vehicle->getLen())
-                        signalSend->target = curLane->getOuterLane();
-                }
-            }
+            if (!router.onValidLane() &&
+            safeDistance() + 50 + vehicle->getLen() + vehicle->getDistance() >= vehicle->getCurLane()->getLength()) {
+                // forced lane change
+                // when the vehicle is on a wrong lane
+                Lane *finalTarget = nearestAvailableLane();
+                if (finalTarget->getLaneIndex() > curLane->getLaneIndex()) changeToOuter();
+                else changeToInner();
+            }else{
+                // optional lane change
 
-            if (curLane->getLaneIndex() > 0){
-                if (router.onLastRoad() || router.getNextDrivable(curLane->getInnerLane())) {
-                    double innerEst = estimateGap(curLane->getInnerLane());
-                    if (innerEst > curEst + vehicle->getLen() && innerEst > outerEst)
-                        signalSend->target = curLane->getInnerLane();
+                if (vehicle->engine->getCurrentTime() - lastChangeTime < coolingTime) return;
+                double outerWeight = std::numeric_limits<double>::lowest();
+                double outerChance = laneChangeChance;
+                double innerWeight = std::numeric_limits<double>::lowest();
+                double innerChance = laneChangeChance;
+                double curEst = vehicle->getLeader() ? vehicle->getGap() : curLane->getLength() - vehicle->getDistance()
+                        - (vehicle->onValidLane() ? 0 : wrongLanePenalty);
+
+                if (curLane->getLaneIndex() < curRoad->getLanes().size() - 1) {
+                    Lane *outerLane = curLane->getOuterLane();
+                    outerWeight = estimateGap(outerLane) - curEst - changeLanePenalty;
+                    if (!router.onLastRoad() && !router.getNextDrivable(outerLane)) {
+                        double safeDis = safeDistance(outerLane) +
+                                         safeDistance((curLane->getWidth() + outerLane->getWidth()) / 2) +
+                                         vehicle->getLen();
+                        if (safeDis + vehicle->getDistance() > curLane->getLength())
+                            outerWeight = std::numeric_limits<double>::lowest();
+                        else {
+                            outerWeight -= wrongLanePenalty;
+                            outerChance = aggressiveChance;
+                        }
+                    }
                 }
+
+                if (curLane->getLaneIndex() > 0) {
+                    Lane *innerLane = curLane->getInnerLane();
+                    innerWeight = estimateGap(innerLane) - curEst - changeLanePenalty;
+                    if (!router.onLastRoad() && !router.getNextDrivable(innerLane)) {
+                        double safeDis = safeDistance(innerLane) +
+                                         safeDistance((curLane->getWidth() + innerLane->getWidth()) / 2) +
+                                         vehicle->getLen();
+                        if (safeDis + vehicle->getDistance() > curLane->getLength())
+                            innerWeight = std::numeric_limits<double>::lowest();
+                        else {
+                            innerWeight -= wrongLanePenalty;
+                            innerChance = aggressiveChance;
+                        }
+                    }
+                }
+                if (innerWeight < 0 && outerWeight < 0) return;
+                std::uniform_real_distribution<double> dis(0.0, 1.0);
+                double chance = dis(vehicle->engine->rnd);
+                if (innerWeight < outerWeight) {
+                    if (chance <= outerChance) changeToOuter();
+                } else
+                    if (chance <= innerChance) changeToInner();
             }
-            signalSend->urgency = 1;
         }
-        LaneChange::makeSignal(interval);
     }
 
-    double SimpleLaneChange::yieldSpeed(double interval) {
+    double LaneChange::yieldSpeed(double interval) {
         if (planChange()) waitingTime += interval;
         if (signalRecv) {
-            if (vehicle == signalRecv->source->getTargetLeader()) {
-                return 100;
-            } else {
-                Vehicle *source = signalRecv->source;
-                double srcSpeed = source->getSpeed();
-                double gap = source->laneChange->gapBefore() - source->laneChange->safeGapBefore();
+            Vehicle *source = signalRecv->source;
+            double srcSpeed = source->getSpeed();
+            double gap = source->laneChange.gapBefore() - source->laneChange.safeGapBefore() ;
+            if (gap < 0) return vehicle->getMaxSpeed();
+            // If the follower is too fast, let it go.
 
-                double v = vehicle->getNoCollisionSpeed(srcSpeed, source->getMaxNegAcc(), vehicle->getSpeed(),
-                                                        vehicle->getMaxNegAcc(), gap, interval, 0);
+            return vehicle->getNoCollisionSpeed(srcSpeed, source->getMaxNegAcc(), vehicle->getSpeed(),
+                                                vehicle->getMaxNegAcc(), gap, interval, vehicle->getMinGap());
 
-                if (v < 0) v = 100;
-                // If the follower is too fast, let it go.
+        }
+        return vehicle->getMaxSpeed();
+    }
 
-                return v;
+    void LaneChange::sendSignal() {
+        if (targetFollower) {
+            auto followers = signalSend->target->getVehiclesBeforeDistance(vehicle->getDistance(),
+                    vehicle->getSegmentIndex(), notifyRange);
+            for (auto &follower : followers){
+                follower->receiveSignal(vehicle);
             }
         }
-        return 100;
     }
 
-    void SimpleLaneChange::sendSignal() {
-        if (targetLeader) targetLeader->receiveSignal(vehicle);
-        if (targetFollower) targetFollower->receiveSignal(vehicle);
-    }
-
-    double SimpleLaneChange::safeGapBefore() const {
+    double LaneChange::safeGapBefore() const {
         return targetFollower ? targetFollower->getMinBrakeDistance() : 0;
     }
 
-    double SimpleLaneChange::safeGapAfter() const {
+    double LaneChange::safeGapAfter() const {
         return vehicle->getMinBrakeDistance();
     }
 
-    double SimpleLaneChange::estimateGap(const Lane *lane) const {
+    double LaneChange::estimateGap(const Lane *lane) const {
         int curSegIndex = vehicle->getSegmentIndex();
         Vehicle *leader = lane->getVehicleAfterDistance(vehicle->getDistance(), curSegIndex);
-        if (!leader) return lane->getLength()-vehicle->getDistance();
+        if (!leader) return lane->getLength() - vehicle->getDistance();
         else return leader->getDistance() - vehicle->getDistance() - leader->getLen();
     }
 

--- a/src/vehicle/router.cpp
+++ b/src/vehicle/router.cpp
@@ -9,7 +9,7 @@
 
 namespace CityFlow {
     Router::Router(const Router &other) : vehicle(other.vehicle), route(other.route),
-            anchorPoints(other.anchorPoints), type(other.type), rnd(other.rnd) {
+            anchorPoints(other.anchorPoints), rnd(other.rnd), type(other.type) {
         iCurRoad = this->route.begin();
     }
 

--- a/src/vehicle/vehicle.h
+++ b/src/vehicle/vehicle.h
@@ -107,7 +107,7 @@ namespace CityFlow {
         double enterTime;
 
 
-        std::shared_ptr<LaneChange> laneChange;
+        LaneChange laneChange;
 
         bool routeValid = false;
         Flow *flow;
@@ -300,26 +300,28 @@ namespace CityFlow {
 
         //for lane change
         inline void makeLaneChangeSignal(double interval){
-            laneChange->makeSignal(interval);
+            laneChange.makeSignal(interval);
         }
 
         inline bool planLaneChange(){
-            return laneChange->planChange();
+            return laneChange.planChange();
         }
 
         void receiveSignal(Vehicle * sender);
 
-        void sendSignal() { laneChange->sendSignal(); }
+        void sendSignal() { laneChange.sendSignal(); }
 
-        void clearSignal(){ laneChange->clearSignal(); }
+        void clearSignal(){ laneChange.clearSignal(); }
 
-        void updateLaneChangeNeighbor(){ laneChange->updateLeaderAndFollower(); }
+        void updateLaneChangeNeighbor(){ laneChange.updateLeaderAndFollower(); }
 
-        std::shared_ptr<LaneChange> getLaneChange(){ return laneChange; }
+        LaneChange &getLaneChange() { return laneChange; }
+
+        const LaneChange &getLaneChange() const { return laneChange; }
 
         std::list<Vehicle *>::iterator getListIterator();
 
-        void insertShadow(Vehicle *shadow) { laneChange->insertShadow(shadow); }
+        void insertShadow(Vehicle *shadow) { laneChange.insertShadow(shadow); }
 
         bool onValidLane() const{ return controllerInfo.router.onValidLane(); }
 
@@ -328,29 +330,29 @@ namespace CityFlow {
             return controllerInfo.router.getValidLane(dynamic_cast<Lane *>(getCurDrivable()));
         }
 
-        bool canChange() const{ return laneChange->canChange(); }
+        bool canChange() const{ return laneChange.canChange(); }
 
         double getGap() const{ return controllerInfo.gap; }
 
-        int laneChangeUrgency() const { return laneChange->signalSend->urgency; }
+        int laneChangeUrgency() const { return laneChange.signalSend->urgency; }
 
-        Vehicle *getTargetLeader() const { return laneChange->targetLeader; }
+        Vehicle *getTargetLeader() const { return laneChange.targetLeader; }
 
-        int lastLaneChangeDirection() const { return laneChange->lastDir; }
+        int lastLaneChangeDirection() const { return laneChange.lastDir; }
 
         int getLaneChangeDirection() const {
-            if (!laneChange->signalSend) return 0;
-            return laneChange->signalSend->direction;
+            if (!laneChange.signalSend) return 0;
+            return laneChange.signalSend->direction;
         }
 
-        bool isChanging() const { return laneChange->changing; }
+        bool isChanging() const { return laneChange.changing; }
 
         double getMaxOffset() const {
-            auto target = laneChange->signalSend->target;
+            auto target = laneChange.signalSend->target;
             return (target->getWidth() + getCurLane()->getWidth()) / 2;
         }
 
-        void abortLaneChange() ;
+//        void abortLaneChange() ;
 
         void updateRoute();
 


### PR DESCRIPTION
- python interface to control lane changing
  + set_lane_change(vehicle_id, direction). Direction can be -1, 0, or 1.
  + get_lane_changing_vehicles: return a list of vehicles carrying out lane change
- remove SimpleLaneChange for simplicity
- open glibc debug flag in CMake

It needs more tests to guarantee reliability and robustness.

For more information see https://docs.google.com/document/d/1mPtqYLS9Ugayj4ROlUwxQ-SD_KmS2Aj8eAgtFErWIlU/edit?usp=sharing