### PR TITLE
refactor: optimization to accelerate

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -869,7 +869,7 @@ namespace CityFlow {
             anchors.emplace_back(anchor);
         }
 
-        return vehicle->setRoute(anchors);
+        return vehicle->setRouteAndUpdate(anchors);
     }
 
     std::map<std::string, std::string> Engine::getVehicleInfo(const std::string &id) const {

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -54,6 +54,8 @@ namespace CityFlow {
         bool rlTrafficLight;
         bool laneChange;
         int manuallyPushCnt = 0;
+        bool staticFlow = true;
+        Router::RouterType routerType = Router::RouterType::LENGTH;
 
         int finishedVehicleCnt = 0;
         double cumulativeTravelTime = 0;
@@ -133,6 +135,8 @@ namespace CityFlow {
         void setLogFile(const std::string &jsonFile, const std::string &logFile);
 
         void initSegments();
+
+        Router::RouterType getRouterType() const { return routerType; }
 
         ~Engine();
 

--- a/src/flow/flow.cpp
+++ b/src/flow/flow.cpp
@@ -18,6 +18,7 @@ namespace CityFlow {
                         route = std::make_shared<std::vector<Road *>>(vehicle->getRoute());
                     }
                     vehicle->setRoute(*route);
+                    vehicle->setFirstDrivable();
                     engine->pushVehicle(vehicle, true);
                 } else {
                     engine->pushVehicle(vehicle, false);

--- a/src/flow/flow.cpp
+++ b/src/flow/flow.cpp
@@ -12,8 +12,17 @@ namespace CityFlow {
                 int priority = vehicle->getPriority();
                 while (engine->checkPriority(priority)) priority = engine->rnd();
                 vehicle->setPriority(priority);
-                engine->pushVehicle(vehicle, false);
-                vehicle->getFirstRoad()->addPlanRouteVehicle(vehicle);
+                if (staticFlow){
+                    if (!route) {
+                        vehicle->updateRoute();
+                        route = std::make_shared<std::vector<Road *>>(vehicle->getRoute());
+                    }
+                    vehicle->setRoute(*route);
+                    engine->pushVehicle(vehicle, true);
+                } else {
+                    engine->pushVehicle(vehicle, false);
+                    vehicle->getFirstRoad()->addPlanRouteVehicle(vehicle);
+                }
                 nowTime -= interval;
             }
             nowTime += timeInterval;

--- a/src/flow/flow.h
+++ b/src/flow/flow.h
@@ -15,7 +15,7 @@ namespace CityFlow {
         friend class Archive;
     private:
         VehicleInfo vehicleTemplate;
-        std::shared_ptr<const Route> route;
+        std::shared_ptr<std::vector<Road *>> route = nullptr;
         double interval;
         double nowTime = 0;
         double currentTime = 0;
@@ -24,13 +24,14 @@ namespace CityFlow {
         int cnt = 0;
         Engine *engine;
         std::string id;
+        bool staticFlow;
         bool valid = true;
 
     public:
         Flow(const VehicleInfo &vehicleTemplate, double timeInterval,
-            Engine *engine, int startTime, int endTime, const std::string &id) 
+            Engine *engine, int startTime, int endTime, const std::string &id, bool staticFlow)
             : vehicleTemplate(vehicleTemplate), interval(timeInterval),
-              startTime(startTime), endTime(endTime), engine(engine), id(id) {
+              startTime(startTime), endTime(endTime), engine(engine), id(id), staticFlow(staticFlow) {
             assert(timeInterval >= 1 || (startTime == endTime));
             nowTime = interval;
         }

--- a/src/roadnet/roadnet.cpp
+++ b/src/roadnet/roadnet.cpp
@@ -182,7 +182,7 @@ namespace CityFlow {
                     roadLink.type = typeMap[getJsonMember<const char*>("type", roadLinkValue)];
                     roadLink.startRoad = roadMap[getJsonMember<const char*>("startRoad", roadLinkValue)];
                     roadLink.endRoad = roadMap[getJsonMember<const char*>("endRoad", roadLinkValue)];
-
+                    roadLink.startRoad->addNeighbor(roadLink.endRoad);
                     const auto &laneLinksValue = getJsonMemberArray("laneLinks", roadLinkValue);
                     roadLink.laneLinks.resize(laneLinksValue.Size());
                     int laneLinkIndex = 0;
@@ -731,14 +731,6 @@ FOUND:;
         double averageSpeed = getAverageSpeed();
         if (averageSpeed < 0) return -1;
         return averageLength() / averageSpeed;
-    }
-
-    bool Road::connectedToRoad(const Road *road) const{
-        for (const auto &lane : getLanes()) {
-            if (lane.getLaneLinksToRoad(road).size())
-                return true;
-        }
-        return false;
     }
 
     void Intersection::reset() {

--- a/src/roadnet/roadnet.h
+++ b/src/roadnet/roadnet.h
@@ -7,6 +7,7 @@
 #include <list>
 #include <map>
 #include <queue>
+#include <set>
 #include <iostream>
 
 namespace CityFlow {
@@ -185,7 +186,7 @@ namespace CityFlow {
         std::vector<Lane *> lanePointers;
 
         std::vector<Vehicle *> planRouteBuffer;
-
+        std::set<const Road *> neighbors;
         void initLanesPoints();
 
     public:
@@ -203,7 +204,9 @@ namespace CityFlow {
 
         void buildSegmentationByInterval(double interval);
 
-        bool connectedToRoad(const Road * road) const;
+        bool connectedToRoad(const Road * road) const {
+            return neighbors.count(road);
+        }
 
         void reset();
 
@@ -228,6 +231,8 @@ namespace CityFlow {
         void clearPlanRouteBuffer() {
             planRouteBuffer.clear();
         }
+
+        void addNeighbor(const Road *road) { neighbors.insert(road); }
     };
 
     class Drivable {

--- a/src/vehicle/router.cpp
+++ b/src/vehicle/router.cpp
@@ -242,7 +242,7 @@ namespace CityFlow {
         return true;
     }
 
-    bool Router::setRoute(const std::vector<Road *> &anchor) {
+    bool Router::setRouteAndUpdate(const std::vector<Road *> &anchor) {
         if (vehicle->getCurDrivable()->isLaneLink()) return false;
         Road *cur_road = *iCurRoad;
         auto backup = std::move(anchorPoints);

--- a/src/vehicle/router.cpp
+++ b/src/vehicle/router.cpp
@@ -8,13 +8,13 @@
 #include <set>
 
 namespace CityFlow {
-    Router::Router(const Router &other) : vehicle(other.vehicle), route(other.route), anchorPoints(other.anchorPoints),
-                                          rnd(other.rnd) {
+    Router::Router(const Router &other) : vehicle(other.vehicle), route(other.route),
+            anchorPoints(other.anchorPoints), type(other.type), rnd(other.rnd) {
         iCurRoad = this->route.begin();
     }
 
-    Router::Router(Vehicle *vehicle, std::shared_ptr<const Route> route, std::mt19937 *rnd)
-        : vehicle(vehicle), anchorPoints(route->getRoute()), rnd(rnd) {
+    Router::Router(Vehicle *vehicle, std::shared_ptr<const Route> route, RouterType type, std::mt19937 *rnd)
+        : vehicle(vehicle), anchorPoints(route->getRoute()), rnd(rnd), type(type) {
         assert(this->anchorPoints.size() > 0);
         this->route = route->getRoute();
         iCurRoad = this->route.begin();

--- a/src/vehicle/router.h
+++ b/src/vehicle/router.h
@@ -81,6 +81,7 @@ namespace CityFlow {
 
         void setRoute(const std::vector<Road *> &route) {
             this->route = route;
+            iCurRoad = this->route.begin();
         }
 
         bool setRouteAndUpdate(const std::vector<Road *> &anchor);

--- a/src/vehicle/router.h
+++ b/src/vehicle/router.h
@@ -79,7 +79,11 @@ namespace CityFlow {
 
         const std::vector<Road *> &getRoute() const { return route; }
 
-        bool setRoute(const std::vector<Road *> &anchor);
+        void setRoute(const std::vector<Road *> &route) {
+            this->route = route;
+        }
+
+        bool setRouteAndUpdate(const std::vector<Road *> &anchor);
 
         std::vector<Road *> getFollowingRoads() const;
     };

--- a/src/vehicle/router.h
+++ b/src/vehicle/router.h
@@ -17,8 +17,14 @@ namespace CityFlow {
 
     class Router {
     friend Archive;
+    public:
+        enum class RouterType{
+            LENGTH,
+            DURATION,
+            DYNAMIC // TODO: dynamic routing
+        };
+
     private:
-        
         Vehicle* vehicle = nullptr;
         std::vector<Road *> route;
         std::vector<Road *> anchorPoints;
@@ -33,19 +39,13 @@ namespace CityFlow {
 
         Lane *selectLane(const Lane *curLane, const std::vector<Lane *> &lanes) const;
 
-        enum class RouterType{
-            LENGTH,
-            DURATION,
-            DYNAMIC // TODO: dynamic routing
-        };
-
         RouterType type = RouterType::LENGTH;
 
     public:
 
         Router(const Router &other);
 
-        Router(Vehicle *vehicle, std::shared_ptr<const Route> route, std::mt19937 *rnd);
+        Router(Vehicle *vehicle, std::shared_ptr<const Route> route, RouterType type, std::mt19937 *rnd);
 
         Road *getFirstRoad() {
             return anchorPoints[0];
@@ -76,6 +76,8 @@ namespace CityFlow {
         bool dijkstra(Road *start, Road *end, std::vector<Road *> &buffer);
 
         bool updateShortestPath();
+
+        const std::vector<Road *> &getRoute() const { return route; }
 
         bool setRoute(const std::vector<Road *> &anchor);
 

--- a/src/vehicle/vehicle.cpp
+++ b/src/vehicle/vehicle.cpp
@@ -8,7 +8,7 @@
 namespace CityFlow {
 
     Vehicle::ControllerInfo::ControllerInfo(Vehicle *vehicle, std::shared_ptr<const Route> route, std::mt19937 *rnd)
-        : router(vehicle, route, rnd) {
+        : router(vehicle, route, vehicle->engine->getRouterType(), rnd) {
         enterLaneLinkTime = std::numeric_limits<int>::max();
     }
 
@@ -17,18 +17,18 @@ namespace CityFlow {
     }
 
     Vehicle::Vehicle(const Vehicle &vehicle, Flow *flow)
-        : vehicleInfo(vehicle.vehicleInfo), controllerInfo(this, vehicle.controllerInfo),
+        : engine(vehicle.engine), vehicleInfo(vehicle.vehicleInfo), controllerInfo(this, vehicle.controllerInfo),
           laneChangeInfo(vehicle.laneChangeInfo), buffer(vehicle.buffer), priority(vehicle.priority),
-          id(vehicle.id), engine(vehicle.engine),
+          id(vehicle.id),
           laneChange(std::make_shared<SimpleLaneChange>(this, *vehicle.laneChange)),
           flow(flow){
         enterTime = vehicle.enterTime;
     }
 
     Vehicle::Vehicle(const Vehicle &vehicle, const std::string &id, Engine *engine, Flow *flow)
-        : vehicleInfo(vehicle.vehicleInfo), controllerInfo(this, vehicle.controllerInfo),
+        : engine(engine), vehicleInfo(vehicle.vehicleInfo), controllerInfo(this, vehicle.controllerInfo),
           laneChangeInfo(vehicle.laneChangeInfo), buffer(vehicle.buffer), 
-          id(id), engine(engine), laneChange(std::make_shared<SimpleLaneChange>(this)),
+          id(id),  laneChange(std::make_shared<SimpleLaneChange>(this)),
           flow(flow){
         while (engine->checkPriority(priority = engine->rnd()));
         controllerInfo.router.setVehicle(this);
@@ -36,8 +36,8 @@ namespace CityFlow {
     }
 
     Vehicle::Vehicle(const VehicleInfo &vehicleInfo, const std::string &id, Engine *engine, Flow *flow)
-        : vehicleInfo(vehicleInfo), controllerInfo(this, vehicleInfo.route, &(engine->rnd)),
-          id(id), engine(engine), laneChange(std::make_shared<SimpleLaneChange>(this)),
+        : engine(engine), vehicleInfo(vehicleInfo), controllerInfo(this, vehicleInfo.route, &(engine->rnd)),
+          id(id), laneChange(std::make_shared<SimpleLaneChange>(this)),
           flow(flow){
         controllerInfo.approachingIntersectionDistance =
             vehicleInfo.maxSpeed * vehicleInfo.maxSpeed / vehicleInfo.usualNegAcc / 2 +
@@ -417,6 +417,10 @@ namespace CityFlow {
 
     Road *Vehicle::getFirstRoad() {
         return controllerInfo.router.getFirstRoad();
+    }
+
+    const std::vector<Road *> &Vehicle::getRoute() const {
+        return controllerInfo.router.getRoute();
     }
 
     void Vehicle::setFirstDrivable() {

--- a/src/vehicle/vehicle.cpp
+++ b/src/vehicle/vehicle.cpp
@@ -431,8 +431,12 @@ namespace CityFlow {
         routeValid = controllerInfo.router.updateShortestPath();
     }
 
-    bool Vehicle::setRoute(const std::vector<Road *> &anchor) {
-        return controllerInfo.router.setRoute(anchor);
+    void Vehicle::setRoute(const std::vector<Road *> &route) {
+        controllerInfo.router.setRoute(route);
+    }
+    
+    bool Vehicle::setRouteAndUpdate(const std::vector<Road *> &anchor) {
+        return controllerInfo.router.setRouteAndUpdate(anchor);
     }
 
 

--- a/src/vehicle/vehicle.h
+++ b/src/vehicle/vehicle.h
@@ -51,6 +51,8 @@ namespace CityFlow {
         friend class SimpleLaneChange;
         friend class Archive;
     private:
+        Engine *engine;
+
         struct Buffer {
             bool isDisSet = false;
             bool isSpeedSet = false;
@@ -104,7 +106,6 @@ namespace CityFlow {
         std::string id;
         double enterTime;
 
-        Engine *engine;
 
         std::shared_ptr<LaneChange> laneChange;
 
@@ -363,10 +364,11 @@ namespace CityFlow {
 
         bool setRoute(const std::vector<Road *> &anchor);
 
-        std::map<std::string, std::string> getInfo() const;
+        const std::vector<Road *> &getRoute() const;
 
+        std::map<std::string, std::string> getInfo() const;
      };
 
-}
+    }
 
 #endif

--- a/src/vehicle/vehicle.h
+++ b/src/vehicle/vehicle.h
@@ -362,7 +362,9 @@ namespace CityFlow {
 
         Flow *getFlow() { return flow; }
 
-        bool setRoute(const std::vector<Road *> &anchor);
+        void setRoute(const std::vector<Road *> &route);
+
+        bool setRouteAndUpdate(const std::vector<Road *> &anchor);
 
         const std::vector<Road *> &getRoute() const;
 


### PR DESCRIPTION
- Add "routingMode" option in the config file
- When routingMode is 'length', that is the metric of the shortest path is length, each flow uses a fixed route which won't be recomputed.
- Optimize connectedToRoad using a cached set of adjacent roads.