### PR TITLE
fix: stack overflow in double2string, verbose always true in simple_run

### DIFF
--- a/src/utility/utility.h
+++ b/src/utility/utility.h
@@ -72,7 +72,7 @@ namespace CityFlow {
     }
     
     inline std::string double2string(double x) {
-        char ret[20];
+        char ret[30];
         dtoa_milo(x, ret);
         std::string str(ret);
         return str;

--- a/tools/debug/simple_run.cpp
+++ b/tools/debug/simple_run.cpp
@@ -28,12 +28,11 @@ int main(int argc, char const *argv[]) {
 
     parser.add_option("--verbose", "-v")
             .help("be verbose")
-            .default_value(false)
             .mode(optionparser::StorageMode::STORE_TRUE);
 
     parser.eat_arguments(argc, argv);
     std::string configFile = parser.get_value<std::string>("configFile");
-    bool verbose = parser.get_value<bool>("verbose");
+    bool verbose = parser.get_value("verbose");
     size_t totalStep = parser.get_value<int>("totalStep");
     size_t threadNum = parser.get_value<int>("threadNum");
 


### PR DESCRIPTION
- fix: stack overflow in double2string, dtoa_milo may generate string
       with at most 26 characters 
- fix: simple_run.cpp: verbose always true, shouldn't set default_value