### PR TITLE
Add time to get_vehicle_info

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -119,6 +119,7 @@ Data Access API
         * ``road``: The id of the current road if the vehicle is running on a lane.
         * ``intersection``: The next intersection if the vehicle is running on a lane.
         * ``route``: A string contains ids of following roads in the vehicle's route which are separated by ``' '``.
+        * ``time``: The time the vehicle has spent travelling.
 
 - Note that all items are stored as ``str``.
 

--- a/src/vehicle/vehicle.cpp
+++ b/src/vehicle/vehicle.cpp
@@ -452,6 +452,7 @@ namespace CityFlow {
             route += r->getId() + " ";
         }
         info["route"] = route;
+        info["time"] = std::to_string(engine->getCurrentTime() - getEnterTime());
 
         return info;
     }


### PR DESCRIPTION
Added the time a vehicle has spent in the simulation to get_vehicle_info()
This allows users to access more information rather than just looking at the average travel time.
Users may want to see the distribution of travel times for calculating metrics for example in: https://www.tandfonline.com/doi/full/10.1080/23249935.2019.1692959