### PR TITLE
change the writeFlags of rapidjson writter from defualt to kWriteNanAndInfFlag

### DIFF
--- a/src/utility/utility.cpp
+++ b/src/utility/utility.cpp
@@ -120,7 +120,7 @@ namespace CityFlow {
         }
         char writeBuffer[JSON_BUFFER_SIZE];
         rapidjson::FileWriteStream os(fp, writeBuffer, sizeof(writeBuffer));
-        rapidjson::Writer<rapidjson::FileWriteStream> writer(os);
+        rapidjson::Writer<rapidjson::FileWriteStream, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag> writer(os);
         document.Accept(writer);
         fclose(fp);
         return true;


### PR DESCRIPTION
Sometimes when I call the archive.dump() function, the json file is not saved. Then I find vehicle.ControllerInfo.gap may be nan and save failed.