### PR TITLE
Fix variable name from config_path to config_file

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -15,10 +15,10 @@ Create Engine
 .. code-block:: python
     
     import cityflow
-    eng = cityflow.Engine(config_path, thread_num=1)
+    eng = cityflow.Engine(config_file, thread_num=1)
 
 
-- ``config_path``: path for config file.
+- ``config_file``: path for config file.
 - ``thread_num``: number of threads.
 
 Arguments In Config File


### PR DESCRIPTION
The param name is `config_file` in source code.

https://github.com/cityflow-project/CityFlow/blob/81ee0f47659ca66177a71f81676691c58ee89184/src/engine/engine.cpp#L13